### PR TITLE
Add batch-1 huggingface_hub compatibility tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,6 +85,10 @@ jobs:
           uv run tests/integration/integration_hffilesystem.py
           uv run tests/integration/test_downloads.py
 
+      - name: run hf_hub pytest compatibility tests
+        run: |
+          uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub -q
+
       - name: fetch Docker logs on failure
         if: failure()
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,7 +85,7 @@ jobs:
           uv run tests/integration/integration_hffilesystem.py
           uv run tests/integration/test_downloads.py
 
-      - name: run hf_hub pytest compatibility tests
+      - name: run huggingface-hub compatibility tests
         run: |
           uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub -q
 

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,5 +1,5 @@
 use axum::{
-    http::StatusCode,
+    http::{HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -34,21 +34,49 @@ pub enum AppError {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let (status, msg) = match &self {
-            AppError::Config(m) => (StatusCode::INTERNAL_SERVER_ERROR, m.clone()),
-            AppError::NotFound(m) => (StatusCode::NOT_FOUND, m.clone()),
-            AppError::BadRequest(m) => (StatusCode::BAD_REQUEST, m.clone()),
-            AppError::Unauthorized(m) => (StatusCode::UNAUTHORIZED, m.clone()),
-            AppError::Forbidden(m) => (StatusCode::FORBIDDEN, m.clone()),
-            AppError::Conflict(m) => (StatusCode::CONFLICT, m.clone()),
+        let (status, msg, error_code) = match &self {
+            AppError::Config(m) => (StatusCode::INTERNAL_SERVER_ERROR, m.clone(), None),
+            AppError::NotFound(m) => (
+                StatusCode::NOT_FOUND,
+                m.clone(),
+                Some(classify_not_found_error(m)),
+            ),
+            AppError::BadRequest(m) => (StatusCode::BAD_REQUEST, m.clone(), None),
+            AppError::Unauthorized(m) => (StatusCode::UNAUTHORIZED, m.clone(), None),
+            AppError::Forbidden(m) => (StatusCode::FORBIDDEN, m.clone(), None),
+            AppError::Conflict(m) => (StatusCode::CONFLICT, m.clone(), None),
             AppError::RangeNotSatisfiable => (
                 StatusCode::RANGE_NOT_SATISFIABLE,
                 "Range not satisfiable".into(),
+                None,
             ),
-            AppError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m.clone()),
+            AppError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m.clone(), None),
         };
         tracing::error!(error = %self, "Request error");
-        (status, Json(json!({ "error": msg }))).into_response()
+
+        let mut response = (status, Json(json!({ "error": msg }))).into_response();
+        if let Some(error_code) = error_code {
+            response
+                .headers_mut()
+                .insert("X-Error-Code", HeaderValue::from_static(error_code));
+        }
+        if let Ok(error_message) = HeaderValue::from_str(&msg) {
+            response
+                .headers_mut()
+                .insert("X-Error-Message", error_message);
+        }
+        response
+    }
+}
+
+fn classify_not_found_error(message: &str) -> &'static str {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("revision") {
+        "RevisionNotFound"
+    } else if lower.contains("repo") {
+        "RepoNotFound"
+    } else {
+        "EntryNotFound"
     }
 }
 

--- a/crates/hub-api/src/auth.rs
+++ b/crates/hub-api/src/auth.rs
@@ -29,8 +29,8 @@ pub fn verify_password(password: &str, hash: &str) -> Result<bool, AppError> {
 
 /// Generate a new ox_* API token. Returns (plaintext_token, sha256_hash).
 pub fn generate_api_token() -> (String, Vec<u8>) {
-    let mut rng = rand::thread_rng();
-    let random_bytes: [u8; 32] = rng.gen();
+    let mut rng = rand::rng();
+    let random_bytes: [u8; 32] = rng.random();
     let token = format!("ox_{}", hex::encode(random_bytes));
     let hash = sha256_hash(token.as_bytes());
     (token, hash)

--- a/crates/hub-api/src/routes/repos.rs
+++ b/crates/hub-api/src/routes/repos.rs
@@ -299,6 +299,7 @@ pub struct DeleteRepoRequest {
     #[serde(rename = "type")]
     pub repo_type: Option<String>,
     pub name: Option<String>,
+    pub organization: Option<String>,
 }
 
 pub async fn delete_repo(
@@ -310,9 +311,17 @@ pub async fn delete_repo(
         .ok_or_else(|| AppError::Unauthorized("missing bearer token".into()))?;
     let user_id = auth::resolve_bearer_token(&state.pool, token).await?;
 
-    let full_name = req
+    let name = req
         .name
         .ok_or_else(|| AppError::BadRequest("name is required".into()))?;
+
+    let full_name = if name.contains('/') {
+        name
+    } else if let Some(organization) = req.organization {
+        format!("{}/{}", organization, name)
+    } else {
+        name
+    };
 
     let repo = db_layer::queries::repositories::find_repo_by_full_name(&state.pool, &full_name)
         .await

--- a/docs/feature_support_matrix.md
+++ b/docs/feature_support_matrix.md
@@ -2,6 +2,8 @@
 
 This matrix details the features of the Hugging Face Hub ecosystem and their current support in our custom Xet Storage Backend. Our goal is to provide a complete drop-in replacement for the core features needed to manage datasets and models.
 
+> This matrix stays intentionally high level. Detailed `huggingface_hub` client compatibility is tracked batch-by-batch in `docs/hf_hub_testing_roadmap.md` and `resources/hf_hub_compat/checklist.json`.
+
 | Feature / Use Case | Description | In Roadmap | Implemented |
 | :--- | :--- | :---: | :---: |
 | **Download files** | `hf_hub_download`, `snapshot_download`, specific revisions, and allow/ignore patterns. | Yes | ✅ |

--- a/docs/hf_hub_testing_roadmap.md
+++ b/docs/hf_hub_testing_roadmap.md
@@ -1,0 +1,193 @@
+# HF Hub Compatibility Testing Roadmap
+
+This document is the curated source of truth for `huggingface_hub` client compatibility work in this repository.
+
+It distills the raw upstream test analysis from [issue #11](https://github.com/Atena-IT/xet-backend/issues/11), [issue #13](https://github.com/Atena-IT/xet-backend/issues/13), [issue #14](https://github.com/Atena-IT/xet-backend/issues/14), [issue #15](https://github.com/Atena-IT/xet-backend/issues/15), [issue #16](https://github.com/Atena-IT/xet-backend/issues/16), and the analysis-only [PR #12](https://github.com/Atena-IT/xet-backend/pull/12) into an ordered delivery queue that can be maintained on `master`.
+
+## Operating rules
+
+- Track compatibility work by user workflow, not by raw upstream file count.
+- Keep exactly one active compatibility batch issue/branch/PR at a time.
+- Update this roadmap and `resources/hf_hub_compat/checklist.json` in the same PR as the executable work.
+- Reuse the existing pytest harness under `tests/integration/hf_hub/` and the `uv`-based CI entrypoint.
+- Treat PR #12 as source material only; do not merge the raw inventory artifacts into mainline.
+
+## Status model
+
+- `done`: merged and passing in CI
+- `in_progress`: currently active issue/branch/PR
+- `planned`: queued work with defined scope
+- `blocked`: intentionally paused behind a dependency or architectural gap
+- `out_of_scope`: explicitly excluded from the current compatibility target
+
+## Current sequence
+
+| Batch | Status | Scope summary | Upstream modules | Issue | PR |
+| --- | --- | --- | --- | --- | --- |
+| Batch 1 | done | Core `HfApi` CRUD, basic `hf_hub_download`, metadata/cache basics, and core `snapshot_download` flows with pattern filters. | `tests/test_hf_api.py`, `tests/test_file_download.py`, `tests/test_snapshot_download.py` | [#17](https://github.com/Atena-IT/xet-backend/issues/17) | [#23](https://github.com/Atena-IT/xet-backend/pull/23) |
+| Batch 2 | planned | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | TBD | TBD |
+| Batch 3 | planned | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | TBD | TBD |
+| Batch 4 | planned | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | TBD | TBD |
+| Batch 5 | planned | Branch, tag, and PR-oriented Hub workflows, only if still desired after batch 4. | `tests/test_hf_api.py`, `tests/test_cli_discussions.py` | TBD | TBD |
+| Batch 6 | planned | LFS/Xet-heavy and filesystem-heavy compatibility where it directly exercises supported server behavior. | `tests/test_hf_file_system.py`, `tests/test_xet_upload.py`, `tests/test_xet_download.py`, `tests/test_repocard.py` | TBD | TBD |
+
+## Batch details
+
+### Batch 1 — core Hub CRUD and basic download workflows
+
+**Status:** `done`
+
+**What it covers**
+- `HfApi` basics: `repo_exists`, `file_exists`, `revision_exists`, `whoami`, delete-missing repo behavior
+- write-path happy paths: `upload_file`, `upload_folder`, `delete_file`, `create_commit`
+- `hf_hub_download` against current head and `main`
+- file metadata and cache basics via `get_hf_file_metadata` and `try_to_load_from_cache`
+- `snapshot_download` happy paths, `local_dir`, `allow_patterns`, and `ignore_patterns`
+- CI execution of the pytest-based compatibility slice
+
+**Local test files**
+- `tests/integration/hf_hub/test_hf_api_batch1.py`
+- `tests/integration/hf_hub/test_file_download_batch1.py`
+- `tests/integration/hf_hub/test_snapshot_download_batch1.py`
+- `.github/workflows/integration-tests.yml`
+
+**Server surfaces already exercised**
+- `crates/hub-api/src/routes/repos.rs`
+- `crates/hub-api/src/routes/files.rs`
+- `crates/common/src/error.rs`
+
+**Merged implementation**
+- Issue: [#17](https://github.com/Atena-IT/xet-backend/issues/17)
+- PR: [#23](https://github.com/Atena-IT/xet-backend/pull/23)
+
+### Batch 2 — deeper download and cache semantics
+
+**Status:** `planned`
+
+**Target**
+- extend `hf_hub_download` and `snapshot_download` coverage beyond batch-1 happy paths
+- add cache reuse, metadata, and local-dir/cache edge cases that fit the current architecture
+- keep the work focused on read-path compatibility rather than expanding unrelated API surface
+
+**Likely local files**
+- `tests/integration/hf_hub/test_file_download_batch2.py`
+- `tests/integration/hf_hub/test_snapshot_download_batch2.py`
+- `tests/integration/hf_hub/helpers.py` (narrow fixture/helper updates only if needed)
+
+**Likely server surfaces**
+- `crates/hub-api/src/routes/files.rs`
+
+**Exit criteria**
+- targeted batch-2 pytest modules pass locally with `uv`
+- full `tests/integration/hf_hub` passes locally
+- overlapping smoke downloads still pass
+- CI is green for the batch PR
+
+### Batch 3 — private repo and auth correctness
+
+**Status:** `planned`
+
+**Target**
+- enforce private/public behavior consistently
+- verify token/no-token behavior across protected reads and metadata calls
+- return the correct 401/403/404 shapes expected by `huggingface_hub`
+
+**Likely local files**
+- `tests/integration/hf_hub/test_auth_batch3.py`
+- `tests/integration/hf_hub/test_repo_visibility_batch3.py`
+
+**Likely server surfaces**
+- `crates/hub-api/src/routes/repos.rs`
+- `crates/hub-api/src/routes/files.rs`
+- auth-adjacent query/route files as required
+
+**Exit criteria**
+- targeted auth and visibility tests pass locally
+- full `tests/integration/hf_hub` passes locally
+- CI is green for the batch PR
+
+### Batch 4 — revision and history semantics
+
+**Status:** `planned`
+
+**Target**
+- verify commit SHA and revision correctness beyond always returning latest head
+- add lookup/listing semantics that matter for practical download and metadata workflows
+
+**Likely local files**
+- `tests/integration/hf_hub/test_revisions_batch4.py`
+
+**Likely server surfaces**
+- `crates/hub-api/src/routes/repos.rs`
+- commit and file lookup paths involved in revision resolution
+
+**Exit criteria**
+- targeted revision tests pass locally
+- full `tests/integration/hf_hub` passes locally
+- CI is green for the batch PR
+
+### Batch 5 — branches, tags, and PR flows
+
+**Status:** `planned`
+
+**Target**
+- branch-like refs and PR-oriented Hub workflows only if they remain in scope after batch 4
+- keep this batch separate because it is the first point where compatibility would require a wider git-like collaboration model
+
+**Likely local files**
+- new `tests/integration/hf_hub/test_*_batch5.py` modules
+
+**Likely server surfaces**
+- `crates/hub-api/src/routes/repos.rs`
+- branch/tag/PR route and model work as required
+
+**Exit criteria**
+- targeted branch/tag/PR tests pass locally
+- full `tests/integration/hf_hub` passes locally
+- CI is green for the batch PR
+
+### Batch 6 — LFS/Xet-heavy and filesystem-heavy paths
+
+**Status:** `planned`
+
+**Target**
+- deeper `HfFileSystem` compatibility where it directly exercises supported repository behavior
+- Xet-specific upload/download compatibility that aligns with this backend’s storage model
+- selected README/model-card push flows only where they map to supported repo semantics
+
+**Likely local files**
+- new `tests/integration/hf_hub/test_*_batch6.py` modules
+
+**Likely server surfaces**
+- repository file read/write paths
+- LFS/Xet transfer surfaces
+- any required Hub API glue for filesystem-style access
+
+**Exit criteria**
+- targeted batch-6 tests pass locally
+- full `tests/integration/hf_hub` passes locally
+- relevant legacy smoke scripts still pass when overlapping behavior changes
+- CI is green for the batch PR
+
+## Explicit non-goals
+
+The following areas are not part of the current compatibility queue unless the roadmap is intentionally expanded later:
+
+- Spaces
+- Inference APIs and Inference Endpoints
+- Jobs / compute workflows
+- community/discussions beyond what is strictly necessary for repository compatibility
+- buckets, unless they are later promoted into scope as a deliberate product goal
+
+## Delivery loop for every batch after batch 1
+
+1. Create a GitHub issue with exact scope, exclusions, upstream source modules, and exit criteria.
+2. Create an issue-tied branch from updated `master`.
+3. Open a draft PR immediately.
+4. Implement only that batch’s pytest modules plus the minimum server fixes required.
+5. Run focused batch tests, then full `tests/integration/hf_hub`, then overlapping smoke scripts when relevant.
+6. Update this roadmap and `resources/hf_hub_compat/checklist.json` in the same PR.
+7. Wait for GitHub Actions to go green.
+8. Merge the PR and delete the branch.
+9. Close the issue.
+10. Move the pointer to the next planned batch and repeat.

--- a/resources/hf_hub_compat/checklist.json
+++ b/resources/hf_hub_compat/checklist.json
@@ -1,0 +1,229 @@
+{
+  "version": 1,
+  "source_analysis": {
+    "issues": [11, 13, 14, 15, 16],
+    "analysis_pr": 12,
+    "analysis_pr_url": "https://github.com/Atena-IT/xet-backend/pull/12"
+  },
+  "strategy": {
+    "tracking_model": "single_active_batch",
+    "current_pointer": "batch2",
+    "status_values": ["done", "in_progress", "planned", "blocked", "out_of_scope"]
+  },
+  "non_goals": [
+    "spaces",
+    "inference",
+    "jobs",
+    "community_beyond_repo_compat",
+    "buckets_unless_promoted"
+  ],
+  "batches": [
+    {
+      "id": "batch1",
+      "title": "Core HfApi CRUD and basic download workflows",
+      "status": "done",
+      "scope": [
+        "Core HfApi CRUD and auth-adjacent happy paths",
+        "Basic hf_hub_download semantics for current head and main",
+        "File metadata and cache basics",
+        "Core snapshot_download semantics with allow/ignore filters",
+        "Pytest-based CI gate for the compatibility slice"
+      ],
+      "upstream_modules": [
+        "tests/test_hf_api.py",
+        "tests/test_file_download.py",
+        "tests/test_snapshot_download.py"
+      ],
+      "local_test_files": [
+        "tests/integration/hf_hub/test_hf_api_batch1.py",
+        "tests/integration/hf_hub/test_file_download_batch1.py",
+        "tests/integration/hf_hub/test_snapshot_download_batch1.py"
+      ],
+      "server_surfaces": [
+        "crates/hub-api/src/routes/repos.rs",
+        "crates/hub-api/src/routes/files.rs",
+        "crates/common/src/error.rs",
+        ".github/workflows/integration-tests.yml"
+      ],
+      "issue": {
+        "number": 17,
+        "url": "https://github.com/Atena-IT/xet-backend/issues/17"
+      },
+      "pr": {
+        "number": 23,
+        "url": "https://github.com/Atena-IT/xet-backend/pull/23"
+      },
+      "depends_on": [],
+      "exit_criteria": [
+        "Targeted batch-1 pytest modules pass locally",
+        "Full tests/integration/hf_hub suite passes locally",
+        "Overlapping smoke scripts still pass",
+        "GitHub Actions for PR #23 are green"
+      ]
+    },
+    {
+      "id": "batch2",
+      "title": "Deeper download and cache semantics",
+      "status": "planned",
+      "scope": [
+        "More hf_hub_download semantics beyond batch-1 happy paths",
+        "More snapshot_download semantics beyond batch-1 happy paths",
+        "Cache reuse, metadata, and local-dir/cache edge cases that fit the current architecture"
+      ],
+      "upstream_modules": [
+        "tests/test_file_download.py",
+        "tests/test_snapshot_download.py",
+        "tests/test_cache_layout.py",
+        "tests/test_utils_cache.py"
+      ],
+      "local_test_files": [
+        "tests/integration/hf_hub/test_file_download_batch2.py",
+        "tests/integration/hf_hub/test_snapshot_download_batch2.py"
+      ],
+      "server_surfaces": [
+        "crates/hub-api/src/routes/files.rs",
+        "tests/integration/hf_hub/helpers.py"
+      ],
+      "issue": null,
+      "pr": null,
+      "depends_on": ["batch1"],
+      "exit_criteria": [
+        "Targeted batch-2 pytest modules pass locally",
+        "Full tests/integration/hf_hub suite passes locally",
+        "Overlapping download smoke scripts still pass",
+        "Rust tests pass if server code changes",
+        "GitHub Actions are green for the batch PR"
+      ]
+    },
+    {
+      "id": "batch3",
+      "title": "Private repo and auth correctness",
+      "status": "planned",
+      "scope": [
+        "Private/public enforcement",
+        "Token and no-token behavior",
+        "Correct 401, 403, and 404 semantics for protected resources"
+      ],
+      "upstream_modules": [
+        "tests/test_hf_api.py",
+        "tests/test_file_download.py"
+      ],
+      "local_test_files": [
+        "tests/integration/hf_hub/test_auth_batch3.py",
+        "tests/integration/hf_hub/test_repo_visibility_batch3.py"
+      ],
+      "server_surfaces": [
+        "crates/hub-api/src/routes/repos.rs",
+        "crates/hub-api/src/routes/files.rs",
+        "auth-adjacent route/query files"
+      ],
+      "issue": null,
+      "pr": null,
+      "depends_on": ["batch2"],
+      "exit_criteria": [
+        "Targeted auth and visibility tests pass locally",
+        "Full tests/integration/hf_hub suite passes locally",
+        "Rust tests pass if server code changes",
+        "GitHub Actions are green for the batch PR"
+      ]
+    },
+    {
+      "id": "batch4",
+      "title": "Revision and history semantics",
+      "status": "planned",
+      "scope": [
+        "Commit SHA and revision correctness",
+        "Listing and lookup semantics beyond always returning latest head"
+      ],
+      "upstream_modules": [
+        "tests/test_hf_api.py",
+        "tests/test_snapshot_download.py"
+      ],
+      "local_test_files": [
+        "tests/integration/hf_hub/test_revisions_batch4.py"
+      ],
+      "server_surfaces": [
+        "crates/hub-api/src/routes/repos.rs",
+        "commit and file lookup paths involved in revision resolution"
+      ],
+      "issue": null,
+      "pr": null,
+      "depends_on": ["batch3"],
+      "exit_criteria": [
+        "Targeted revision tests pass locally",
+        "Full tests/integration/hf_hub suite passes locally",
+        "Rust tests pass if server code changes",
+        "GitHub Actions are green for the batch PR"
+      ]
+    },
+    {
+      "id": "batch5",
+      "title": "Branches, tags, and PR flows",
+      "status": "planned",
+      "scope": [
+        "Branch-like refs",
+        "Tag semantics",
+        "PR-oriented Hub workflows if still desired after batch 4"
+      ],
+      "upstream_modules": [
+        "tests/test_hf_api.py",
+        "tests/test_cli_discussions.py"
+      ],
+      "local_test_files": [
+        "tests/integration/hf_hub/test_branches_batch5.py",
+        "tests/integration/hf_hub/test_tags_batch5.py",
+        "tests/integration/hf_hub/test_pull_requests_batch5.py"
+      ],
+      "server_surfaces": [
+        "crates/hub-api/src/routes/repos.rs",
+        "branch/tag/PR route and model work"
+      ],
+      "issue": null,
+      "pr": null,
+      "depends_on": ["batch4"],
+      "exit_criteria": [
+        "Targeted branch, tag, and PR tests pass locally",
+        "Full tests/integration/hf_hub suite passes locally",
+        "Rust tests pass if server code changes",
+        "GitHub Actions are green for the batch PR"
+      ]
+    },
+    {
+      "id": "batch6",
+      "title": "LFS/Xet-heavy and filesystem-heavy paths",
+      "status": "planned",
+      "scope": [
+        "Deeper HfFileSystem compatibility for supported repository behavior",
+        "Xet-specific upload and download compatibility",
+        "Selected README or model-card push flows where they map to supported repo semantics"
+      ],
+      "upstream_modules": [
+        "tests/test_hf_file_system.py",
+        "tests/test_xet_upload.py",
+        "tests/test_xet_download.py",
+        "tests/test_repocard.py"
+      ],
+      "local_test_files": [
+        "tests/integration/hf_hub/test_hf_filesystem_batch6.py",
+        "tests/integration/hf_hub/test_xet_upload_batch6.py",
+        "tests/integration/hf_hub/test_xet_download_batch6.py",
+        "tests/integration/hf_hub/test_repocard_batch6.py"
+      ],
+      "server_surfaces": [
+        "repository file read and write paths",
+        "LFS and Xet transfer surfaces",
+        "Hub API glue for filesystem-style access"
+      ],
+      "issue": null,
+      "pr": null,
+      "depends_on": ["batch5"],
+      "exit_criteria": [
+        "Targeted batch-6 tests pass locally",
+        "Full tests/integration/hf_hub suite passes locally",
+        "Relevant smoke scripts still pass when overlapping behavior changes",
+        "Rust tests pass if server code changes",
+        "GitHub Actions are green for the batch PR"
+      ]
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -18,14 +18,28 @@ docker compose up -d --build --wait
 
 ## Running the Tests
 
-All tests are written as **self-contained Python scripts** using PEP 723 inline metadata. This means you do NOT need to manually manage virtual environments or pip installs. We highly recommend using [`uv`](https://github.com/astral-sh/uv) to run them.
+Use [`uv`](https://github.com/astral-sh/uv) for all Python integration coverage.
+
+### Script-based smoke tests
+
+The original smoke tests remain self-contained Python scripts using PEP 723 inline metadata.
 
 ```bash
-# Run a specific integration test using uv (it will auto-install dependencies)
-uv run integration/cdc_csv_demo.py
+HF_ENDPOINT=http://localhost:8080 uv run tests/integration/roundtrip.py
+HF_ENDPOINT=http://localhost:8080 uv run tests/integration/test_downloads.py
+HF_ENDPOINT=http://localhost:8080 uv run tests/integration/integration_create_commit.py
+```
 
-# Or run the basic roundtrip
-uv run integration/roundtrip.py
+### Pytest-based `hf_hub` compatibility slice
+
+Batch 1 of the upstream-derived compatibility suite lives under `tests/integration/hf_hub/`.
+These tests reuse the same bootstrap flow as the smoke scripts but run under pytest for better isolation and selective execution.
+
+```bash
+HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_hf_api_batch1.py -q
+HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_snapshot_download_batch1.py -q
+HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_file_download_batch1.py -q
+HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub -q
 ```
 
 ## Test Categories

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -2,6 +2,10 @@
 
 This folder contains Python scripts demonstrating the capabilities of the Xet Hub Backend and acting as integration tests against the `huggingface_hub` Python library.
 
+The long-running `huggingface_hub` compatibility rollout is tracked in:
+- `docs/hf_hub_testing_roadmap.md` — the human-readable source of truth for batch scope and status
+- `resources/hf_hub_compat/checklist.json` — the machine-readable tracker used to keep batch state aligned with implementation work
+
 ## Setup
 
 To run these integration tests, you must have the local Docker Compose stack running, which spins up the Xet Hub server, PostgreSQL, and MinIO.
@@ -34,6 +38,7 @@ HF_ENDPOINT=http://localhost:8080 uv run tests/integration/integration_create_co
 
 Batch 1 of the upstream-derived compatibility suite lives under `tests/integration/hf_hub/`.
 These tests reuse the same bootstrap flow as the smoke scripts but run under pytest for better isolation and selective execution.
+Future batches should continue the additive naming pattern `test_<feature>_batch<N>.py` and must update the roadmap/checklist in the same PR as any new compatibility work.
 
 ```bash
 HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_hf_api_batch1.py -q

--- a/tests/integration/hf_hub/conftest.py
+++ b/tests/integration/hf_hub/conftest.py
@@ -1,0 +1,66 @@
+import os
+
+os.environ.setdefault("HF_HUB_DISABLE_SYMLINKS_WARNING", "1")
+
+import pytest
+from huggingface_hub import HfApi
+
+from helpers import (
+    DEFAULT_ENDPOINT,
+    DEFAULT_PASSWORD,
+    configure_environment,
+    delete_repo_direct,
+    make_repo_id,
+    register_or_login,
+    wait_for_server,
+)
+
+
+@pytest.fixture(scope="session")
+def hf_endpoint() -> str:
+    return os.environ.get("HF_ENDPOINT", DEFAULT_ENDPOINT)
+
+
+@pytest.fixture(scope="session")
+def hf_session(hf_endpoint: str) -> dict[str, str]:
+    wait_for_server(hf_endpoint)
+    username = os.environ.get("HF_TEST_USERNAME", "pytest-hf-hub")
+    password = os.environ.get("HF_TEST_PASSWORD", DEFAULT_PASSWORD)
+    token = register_or_login(hf_endpoint, username, password)
+    configure_environment(hf_endpoint, token)
+    return {
+        "endpoint": hf_endpoint,
+        "username": username,
+        "password": password,
+        "token": token,
+    }
+
+
+@pytest.fixture
+def hf_api(hf_session: dict[str, str]) -> HfApi:
+    configure_environment(hf_session["endpoint"], hf_session["token"])
+    return HfApi(endpoint=hf_session["endpoint"], token=hf_session["token"])
+
+
+@pytest.fixture
+def repo_factory(hf_api: HfApi, hf_session: dict[str, str]):
+    created_repos: list[tuple[str, str]] = []
+
+    def create_repo(prefix: str, repo_type: str = "model") -> str:
+        repo_id = make_repo_id(hf_session["username"], prefix)
+        hf_api.create_repo(repo_id=repo_id, repo_type=repo_type)
+        created_repos.append((repo_id, repo_type))
+        return repo_id
+
+    yield create_repo
+
+    for repo_id, repo_type in reversed(created_repos):
+        try:
+            hf_api.delete_repo(repo_id=repo_id, repo_type=repo_type, missing_ok=True)
+        except Exception:
+            delete_repo_direct(
+                endpoint=hf_session["endpoint"],
+                token=hf_session["token"],
+                repo_id=repo_id,
+                repo_type=repo_type,
+            )

--- a/tests/integration/hf_hub/helpers.py
+++ b/tests/integration/hf_hub/helpers.py
@@ -1,0 +1,79 @@
+import os
+import time
+import uuid
+from pathlib import Path
+
+import requests
+
+DEFAULT_ENDPOINT = os.environ.get("HF_ENDPOINT", "http://localhost:8080")
+DEFAULT_PASSWORD = os.environ.get("HF_TEST_PASSWORD", "pytest-hf-hub-password")
+
+
+def wait_for_server(endpoint: str, timeout: int = 60) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            response = requests.get(f"{endpoint}/health", timeout=3)
+            response.raise_for_status()
+            if response.json().get("status") == "ok":
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(1)
+    raise RuntimeError(f"Server not ready at {endpoint} after {timeout}s")
+
+
+def login_user(endpoint: str, username: str, password: str) -> str:
+    response = requests.post(
+        f"{endpoint}/api/auth/login",
+        json={"username": username, "password": password},
+        timeout=10,
+    )
+    response.raise_for_status()
+    return response.json()["token"]
+
+
+def register_or_login(endpoint: str, username: str, password: str) -> str:
+    response = requests.post(
+        f"{endpoint}/api/auth/register",
+        json={"username": username, "password": password},
+        timeout=10,
+    )
+    if response.status_code == 409:
+        return login_user(endpoint, username, password)
+    response.raise_for_status()
+    return response.json()["token"]
+
+
+def configure_environment(endpoint: str, token: str | None = None) -> None:
+    os.environ["HF_ENDPOINT"] = endpoint
+    os.environ["CURL_CA_BUNDLE"] = ""
+    os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
+    if token is not None:
+        os.environ["HF_TOKEN"] = token
+
+
+def make_repo_id(owner: str, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    return f"{owner}/{prefix}-{int(time.time())}-{suffix}"
+
+
+def delete_repo_direct(endpoint: str, token: str, repo_id: str, repo_type: str = "model") -> None:
+    response = requests.delete(
+        f"{endpoint}/api/repos/delete",
+        json={"name": repo_id, "type": repo_type},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    if response.status_code not in {200, 404}:
+        response.raise_for_status()
+
+
+def write_tree(root: Path, files: dict[str, str | bytes]) -> None:
+    for relative_path, content in files.items():
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, str):
+            path.write_text(content, encoding="utf-8")
+        else:
+            path.write_bytes(content)

--- a/tests/integration/hf_hub/test_file_download_batch1.py
+++ b/tests/integration/hf_hub/test_file_download_batch1.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+from huggingface_hub import hf_hub_download, hf_hub_url
+from huggingface_hub.file_download import get_hf_file_metadata, try_to_load_from_cache
+
+
+def _create_download_repo(hf_api, repo_factory):
+    repo_id = repo_factory("file-download")
+    content = b'{"model_type": "gpt2", "batch": 1}'
+    hf_api.upload_file(
+        path_or_fileobj=content,
+        path_in_repo="config.json",
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Upload config.json",
+    )
+    return repo_id, content
+
+
+def test_hf_hub_download_current_head(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, expected_content = _create_download_repo(hf_api, repo_factory)
+
+    downloaded_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="config.json",
+        repo_type="model",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache",
+    )
+
+    assert Path(downloaded_path).read_bytes() == expected_content
+
+
+def test_hf_hub_download_revision_main(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, expected_content = _create_download_repo(hf_api, repo_factory)
+
+    downloaded_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="config.json",
+        repo_type="model",
+        revision="main",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache",
+    )
+
+    assert Path(downloaded_path).read_bytes() == expected_content
+
+
+def test_get_hf_file_metadata_basic(hf_api, hf_session, repo_factory):
+    repo_id, expected_content = _create_download_repo(hf_api, repo_factory)
+    repo_info = hf_api.model_info(repo_id)
+    file_url = hf_hub_url(
+        repo_id=repo_id,
+        filename="config.json",
+        repo_type="model",
+        endpoint=hf_session["endpoint"],
+    )
+
+    metadata = get_hf_file_metadata(file_url, token=hf_session["token"])
+
+    assert metadata.commit_hash == repo_info.sha
+    assert metadata.etag is not None
+    assert metadata.size == len(expected_content)
+
+
+def test_try_to_load_from_cache_after_download(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, _ = _create_download_repo(hf_api, repo_factory)
+    cache_dir = tmp_path / "cache"
+
+    downloaded_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="config.json",
+        repo_type="model",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=cache_dir,
+    )
+
+    assert try_to_load_from_cache(repo_id, filename="config.json", cache_dir=cache_dir) == downloaded_path
+    assert (
+        try_to_load_from_cache(repo_id, filename="config.json", cache_dir=cache_dir, revision="main")
+        == downloaded_path
+    )

--- a/tests/integration/hf_hub/test_hf_api_batch1.py
+++ b/tests/integration/hf_hub/test_hf_api_batch1.py
@@ -1,0 +1,227 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from huggingface_hub import CommitOperationAdd, CommitOperationDelete, HfApi, hf_hub_download
+from huggingface_hub.errors import EntryNotFoundError
+
+from helpers import make_repo_id, write_tree
+
+
+def test_repo_exists_file_exists_and_revision_exists(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = repo_factory("hf-api-exists")
+    hf_api.upload_file(
+        path_or_fileobj=b"content",
+        path_in_repo="file.txt",
+        repo_id=repo_id,
+        commit_message="Add file.txt",
+    )
+
+    missing_repo_id = make_repo_id(hf_session["username"], "missing-repo")
+
+    assert hf_api.repo_exists(repo_id)
+    assert not hf_api.repo_exists(missing_repo_id)
+    assert hf_api.file_exists(repo_id, "file.txt")
+    assert not hf_api.file_exists(repo_id, "missing.txt")
+    assert hf_api.revision_exists(repo_id, "main")
+
+    downloaded_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="file.txt",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache",
+    )
+    assert downloaded_path
+
+
+def test_whoami_with_passing_token(hf_session):
+    api = HfApi(endpoint=hf_session["endpoint"])
+    info = api.whoami(token=hf_session["token"])
+
+    assert info["name"] == hf_session["username"]
+    assert info["fullname"] == hf_session["username"]
+    assert isinstance(info["orgs"], list)
+
+
+def test_whoami_with_caching(hf_session):
+    api = HfApi(endpoint=hf_session["endpoint"], token=hf_session["token"])
+    assert api._whoami_cache == {}
+
+    info = api.whoami(cache=True)
+    assert info["name"] == hf_session["username"]
+    assert hf_session["token"] in api._whoami_cache
+
+    cached_value = {"name": "cached-value"}
+    api._whoami_cache[hf_session["token"]] = cached_value
+    assert api.whoami(cache=True) == cached_value
+
+    api_bis = HfApi(endpoint=hf_session["endpoint"], token=hf_session["token"])
+    assert api_bis._whoami_cache == {}
+
+
+def test_delete_repo_missing_ok(hf_api, hf_session):
+    missing_repo_id = make_repo_id(hf_session["username"], "missing-delete")
+    hf_api.delete_repo(missing_repo_id, missing_ok=True)
+
+
+def test_upload_file_from_path(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = repo_factory("upload-from-path")
+    source_path = tmp_path / "source.txt"
+    source_path.write_text("Hello from path", encoding="utf-8")
+
+    commit_info = hf_api.upload_file(
+        path_or_fileobj=source_path,
+        path_in_repo="temp/new_file.md",
+        repo_id=repo_id,
+        commit_message="Upload from path",
+    )
+
+    assert commit_info.oid
+    downloaded_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="temp/new_file.md",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache",
+    )
+    assert downloaded_path
+    assert (tmp_path / "cache").exists()
+    assert Path(downloaded_path).read_text(encoding="utf-8") == "Hello from path"
+
+
+def test_upload_file_from_file_object(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = repo_factory("upload-from-fileobj")
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"Hello from file object")
+
+    with source_path.open("rb") as handle:
+        commit_info = hf_api.upload_file(
+            path_or_fileobj=handle,
+            path_in_repo="temp/new_file.md",
+            repo_id=repo_id,
+            commit_message="Upload from file object",
+        )
+
+    assert commit_info.oid
+    downloaded_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="temp/new_file.md",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache",
+    )
+    assert Path(downloaded_path).read_bytes() == b"Hello from file object"
+
+
+def test_upload_file_from_bytesio(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = repo_factory("upload-from-bytesio")
+
+    commit_info = hf_api.upload_file(
+        path_or_fileobj=BytesIO(b"Hello from BytesIO"),
+        path_in_repo="temp/new_file.md",
+        repo_id=repo_id,
+        commit_message="Upload from BytesIO",
+    )
+
+    assert commit_info.oid
+    downloaded_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="temp/new_file.md",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache",
+    )
+    assert Path(downloaded_path).read_bytes() == b"Hello from BytesIO"
+
+
+def test_upload_folder_basic(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = repo_factory("upload-folder")
+    upload_dir = tmp_path / "upload"
+    write_tree(
+        upload_dir,
+        {
+            "config.json": '{"model_type": "dummy"}',
+            "nested/weights.bin": b"weights",
+        },
+    )
+
+    commit_info = hf_api.upload_folder(
+        folder_path=upload_dir,
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Upload folder",
+    )
+
+    assert commit_info.oid
+    config_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="config.json",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache-config",
+    )
+    nested_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="nested/weights.bin",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache-nested",
+    )
+    assert Path(config_path).read_text(encoding="utf-8") == '{"model_type": "dummy"}'
+    assert Path(nested_path).read_bytes() == b"weights"
+
+
+def test_delete_file(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = repo_factory("delete-file")
+    hf_api.upload_file(
+        path_or_fileobj=b"temporary content",
+        path_in_repo="temp/new_file.md",
+        repo_id=repo_id,
+    )
+
+    commit_info = hf_api.delete_file(
+        path_in_repo="temp/new_file.md",
+        repo_id=repo_id,
+        commit_message="Delete file",
+    )
+
+    assert commit_info.oid
+    assert not hf_api.file_exists(repo_id, "temp/new_file.md")
+    with pytest.raises(EntryNotFoundError):
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="temp/new_file.md",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache",
+        )
+
+
+def test_create_commit_add_and_delete(hf_api, repo_factory):
+    repo_id = repo_factory("create-commit")
+
+    first_commit = hf_api.create_commit(
+        repo_id=repo_id,
+        commit_message="Initial files",
+        operations=[
+            CommitOperationAdd(path_in_repo="file_to_keep.txt", path_or_fileobj=b"Keep me"),
+            CommitOperationAdd(path_in_repo="file_to_delete.txt", path_or_fileobj=b"Delete me later"),
+        ],
+    )
+    assert first_commit.oid
+
+    second_commit = hf_api.create_commit(
+        repo_id=repo_id,
+        commit_message="Add and delete",
+        operations=[
+            CommitOperationAdd(path_in_repo="new_file.txt", path_or_fileobj=b"I am new"),
+            CommitOperationDelete(path_in_repo="file_to_delete.txt"),
+        ],
+    )
+
+    assert second_commit.oid
+    files = set(hf_api.list_repo_files(repo_id))
+    assert "file_to_keep.txt" in files
+    assert "new_file.txt" in files
+    assert "file_to_delete.txt" not in files

--- a/tests/integration/hf_hub/test_snapshot_download_batch1.py
+++ b/tests/integration/hf_hub/test_snapshot_download_batch1.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+from helpers import write_tree
+
+
+def _create_snapshot_repo(hf_api, repo_factory, tmp_path):
+    repo_id = repo_factory("snapshot-download")
+    upload_dir = tmp_path / "upload"
+    write_tree(
+        upload_dir,
+        {
+            "config.json": '{"model_type": "gpt2"}',
+            "vocab.json": '{"a": 1, "b": 2}',
+            "model.safetensors": b"fake weights data",
+            "dummy.txt": "# Test Model\n",
+            "data/train.csv": "col1,col2\n1,2\n",
+        },
+    )
+    hf_api.upload_folder(
+        folder_path=upload_dir,
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Upload snapshot fixture",
+    )
+    return repo_id
+
+
+def test_snapshot_download_current_head_preserves_nested_files(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = _create_snapshot_repo(hf_api, repo_factory, tmp_path)
+
+    snapshot_path = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache",
+        )
+    )
+
+    assert (snapshot_path / "config.json").read_text(encoding="utf-8") == '{"model_type": "gpt2"}'
+    assert (snapshot_path / "model.safetensors").read_bytes() == b"fake weights data"
+    assert (snapshot_path / "data" / "train.csv").read_text(encoding="utf-8") == "col1,col2\n1,2\n"
+
+
+def test_snapshot_download_to_local_dir_is_correct(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = _create_snapshot_repo(hf_api, repo_factory, tmp_path)
+    local_dir = tmp_path / "local-snapshot"
+
+    snapshot_path = snapshot_download(
+        repo_id=repo_id,
+        repo_type="model",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=tmp_path / "cache",
+        local_dir=local_dir,
+    )
+
+    assert Path(snapshot_path) == local_dir
+    assert (local_dir / "config.json").is_file()
+    assert (local_dir / "data" / "train.csv").is_file()
+    assert (local_dir / "dummy.txt").read_text(encoding="utf-8") == "# Test Model\n"
+
+
+def test_snapshot_download_allow_patterns(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = _create_snapshot_repo(hf_api, repo_factory, tmp_path)
+    local_dir = tmp_path / "allow-local"
+
+    snapshot_path = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            local_dir=local_dir,
+            allow_patterns="*.json",
+        )
+    )
+
+    assert (snapshot_path / "config.json").is_file()
+    assert (snapshot_path / "vocab.json").is_file()
+    assert not (snapshot_path / "model.safetensors").exists()
+    assert not (snapshot_path / "data" / "train.csv").exists()
+
+
+def test_snapshot_download_ignore_patterns(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id = _create_snapshot_repo(hf_api, repo_factory, tmp_path)
+    local_dir = tmp_path / "ignore-local"
+
+    snapshot_path = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            local_dir=local_dir,
+            ignore_patterns=["*.safetensors", "data/*"],
+        )
+    )
+
+    assert (snapshot_path / "config.json").is_file()
+    assert (snapshot_path / "vocab.json").is_file()
+    assert not (snapshot_path / "model.safetensors").exists()
+    assert not (snapshot_path / "data" / "train.csv").exists()


### PR DESCRIPTION
## Summary
- add a pytest-based `tests/integration/hf_hub/` compatibility slice covering core `HfApi`, file download, and snapshot download flows
- document the `uv` workflow for the new pytest suite alongside the existing smoke scripts
- align delete-repo request parsing and 404 error headers with `huggingface_hub` client expectations uncovered by the new tests

## Test plan
- [x] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub -q`
- [x] `HF_ENDPOINT=http://localhost:8080 uv run tests/integration/roundtrip.py`
- [x] `HF_ENDPOINT=http://localhost:8080 uv run tests/integration/test_downloads.py`
- [x] `HF_ENDPOINT=http://localhost:8080 uv run tests/integration/integration_create_commit.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)