### PR TITLE
test(hf-hub): batch-2 deeper download and cache semantics

### DIFF
--- a/docs/hf_hub_testing_roadmap.md
+++ b/docs/hf_hub_testing_roadmap.md
@@ -25,7 +25,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 | Batch | Status | Scope summary | Upstream modules | Issue | PR |
 | --- | --- | --- | --- | --- | --- |
 | Batch 1 | done | Core `HfApi` CRUD, basic `hf_hub_download`, metadata/cache basics, and core `snapshot_download` flows with pattern filters. | `tests/test_hf_api.py`, `tests/test_file_download.py`, `tests/test_snapshot_download.py` | [#17](https://github.com/Atena-IT/xet-backend/issues/17) | [#23](https://github.com/Atena-IT/xet-backend/pull/23) |
-| Batch 2 | planned | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | TBD | TBD |
+| Batch 2 | in_progress | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | [#24](https://github.com/Atena-IT/xet-backend/issues/24) | TBD |
 | Batch 3 | planned | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | TBD | TBD |
 | Batch 4 | planned | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | TBD | TBD |
 | Batch 5 | planned | Branch, tag, and PR-oriented Hub workflows, only if still desired after batch 4. | `tests/test_hf_api.py`, `tests/test_cli_discussions.py` | TBD | TBD |
@@ -62,7 +62,8 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 
 ### Batch 2 — deeper download and cache semantics
 
-**Status:** `planned`
+**Status:** `in_progress`
+- Issue: [#24](https://github.com/Atena-IT/xet-backend/issues/24)
 
 **Target**
 - extend `hf_hub_download` and `snapshot_download` coverage beyond batch-1 happy paths

--- a/docs/hf_hub_testing_roadmap.md
+++ b/docs/hf_hub_testing_roadmap.md
@@ -25,7 +25,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 | Batch | Status | Scope summary | Upstream modules | Issue | PR |
 | --- | --- | --- | --- | --- | --- |
 | Batch 1 | done | Core `HfApi` CRUD, basic `hf_hub_download`, metadata/cache basics, and core `snapshot_download` flows with pattern filters. | `tests/test_hf_api.py`, `tests/test_file_download.py`, `tests/test_snapshot_download.py` | [#17](https://github.com/Atena-IT/xet-backend/issues/17) | [#23](https://github.com/Atena-IT/xet-backend/pull/23) |
-| Batch 2 | in_progress | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | [#24](https://github.com/Atena-IT/xet-backend/issues/24) | TBD |
+| Batch 2 | in_progress | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | [#24](https://github.com/Atena-IT/xet-backend/issues/24) | [#25](https://github.com/Atena-IT/xet-backend/pull/25) |
 | Batch 3 | planned | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | TBD | TBD |
 | Batch 4 | planned | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | TBD | TBD |
 | Batch 5 | planned | Branch, tag, and PR-oriented Hub workflows, only if still desired after batch 4. | `tests/test_hf_api.py`, `tests/test_cli_discussions.py` | TBD | TBD |
@@ -64,6 +64,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 
 **Status:** `in_progress`
 - Issue: [#24](https://github.com/Atena-IT/xet-backend/issues/24)
+- PR: [#25](https://github.com/Atena-IT/xet-backend/pull/25)
 
 **Target**
 - extend `hf_hub_download` and `snapshot_download` coverage beyond batch-1 happy paths

--- a/resources/hf_hub_compat/checklist.json
+++ b/resources/hf_hub_compat/checklist.json
@@ -64,7 +64,7 @@
     {
       "id": "batch2",
       "title": "Deeper download and cache semantics",
-      "status": "planned",
+      "status": "in_progress",
       "scope": [
         "More hf_hub_download semantics beyond batch-1 happy paths",
         "More snapshot_download semantics beyond batch-1 happy paths",
@@ -84,7 +84,10 @@
         "crates/hub-api/src/routes/files.rs",
         "tests/integration/hf_hub/helpers.py"
       ],
-      "issue": null,
+      "issue": {
+        "number": 24,
+        "url": "https://github.com/Atena-IT/xet-backend/issues/24"
+      },
       "pr": null,
       "depends_on": ["batch1"],
       "exit_criteria": [

--- a/resources/hf_hub_compat/checklist.json
+++ b/resources/hf_hub_compat/checklist.json
@@ -88,7 +88,10 @@
         "number": 24,
         "url": "https://github.com/Atena-IT/xet-backend/issues/24"
       },
-      "pr": null,
+      "pr": {
+        "number": 25,
+        "url": "https://github.com/Atena-IT/xet-backend/pull/25"
+      },
       "depends_on": ["batch1"],
       "exit_criteria": [
         "Targeted batch-2 pytest modules pass locally",

--- a/tests/integration/hf_hub/conftest.py
+++ b/tests/integration/hf_hub/conftest.py
@@ -3,6 +3,7 @@ import os
 os.environ.setdefault("HF_HUB_DISABLE_SYMLINKS_WARNING", "1")
 
 import pytest
+import huggingface_hub.file_download as hf_file_download
 from huggingface_hub import HfApi
 
 from helpers import (
@@ -14,6 +15,10 @@ from helpers import (
     register_or_login,
     wait_for_server,
 )
+
+if os.name == "nt":
+    hf_file_download.are_symlinks_supported = lambda cache_dir=None: False
+    hf_file_download._are_symlinks_supported_in_dir.clear()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/hf_hub/test_file_download_batch2.py
+++ b/tests/integration/hf_hub/test_file_download_batch2.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+
+import pytest
+from huggingface_hub import hf_hub_download
+from huggingface_hub.errors import LocalEntryNotFoundError
+from huggingface_hub.file_download import try_to_load_from_cache
+
+
+
+def _create_download_repo(hf_api, repo_factory):
+    repo_id = repo_factory("file-download-batch2")
+    content = b'{"model_type": "gpt2", "batch": 2}'
+    hf_api.upload_file(
+        path_or_fileobj=content,
+        path_in_repo="config.json",
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Upload config.json",
+    )
+    return repo_id, content
+
+
+
+def test_hf_hub_download_to_local_dir_after_cache_seed(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, expected_content = _create_download_repo(hf_api, repo_factory)
+    cache_dir = tmp_path / "cache"
+    local_dir = tmp_path / "local"
+
+    cached_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+        )
+    )
+    local_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+            local_dir=local_dir,
+        )
+    )
+
+    assert cached_path.read_bytes() == expected_content
+    assert local_path == local_dir / "config.json"
+    assert local_path.read_bytes() == expected_content
+    assert try_to_load_from_cache(repo_id, filename="config.json", cache_dir=cache_dir) == str(cached_path)
+
+
+
+def test_hf_hub_download_local_files_only_returns_cached_path(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, expected_content = _create_download_repo(hf_api, repo_factory)
+    cache_dir = tmp_path / "cache"
+
+    cached_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="config.json",
+        repo_type="model",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=cache_dir,
+    )
+    local_only_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="config.json",
+        repo_type="model",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=cache_dir,
+        local_files_only=True,
+    )
+
+    assert local_only_path == cached_path
+    assert Path(local_only_path).read_bytes() == expected_content
+
+
+
+def test_hf_hub_download_local_files_only_missing_cache_raises(hf_session, repo_factory, tmp_path):
+    repo_id = repo_factory("file-download-local-only-miss")
+
+    with pytest.raises(LocalEntryNotFoundError):
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache",
+            local_files_only=True,
+        )
+
+
+
+def test_hf_hub_download_refreshes_cached_main_after_new_commit(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, first_content = _create_download_repo(hf_api, repo_factory)
+    cache_dir = tmp_path / "cache"
+
+    first_cached_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+        )
+    )
+
+    updated_content = b'{"model_type": "gpt2", "batch": 2, "version": 2}'
+    hf_api.upload_file(
+        path_or_fileobj=updated_content,
+        path_in_repo="config.json",
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Update config.json",
+    )
+
+    refreshed_cached_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+        )
+    )
+
+    assert first_cached_path.read_bytes() == first_content
+    assert refreshed_cached_path.read_bytes() == updated_content
+    assert refreshed_cached_path != first_cached_path
+    assert try_to_load_from_cache(repo_id, filename="config.json", cache_dir=cache_dir) == str(
+        refreshed_cached_path
+    )
+
+
+
+def test_hf_hub_download_overwrites_stale_local_dir_file(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, expected_content = _create_download_repo(hf_api, repo_factory)
+    cache_dir = tmp_path / "cache"
+    local_dir = tmp_path / "local"
+    local_dir.mkdir(parents=True, exist_ok=True)
+    stale_path = local_dir / "config.json"
+    stale_path.write_text("stale", encoding="utf-8")
+
+    local_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+            local_dir=local_dir,
+        )
+    )
+
+    assert local_path == stale_path
+    assert local_path.read_bytes() == expected_content

--- a/tests/integration/hf_hub/test_snapshot_download_batch2.py
+++ b/tests/integration/hf_hub/test_snapshot_download_batch2.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+
+import pytest
+from huggingface_hub import snapshot_download
+from huggingface_hub.errors import LocalEntryNotFoundError
+
+from helpers import write_tree
+
+
+
+def _create_snapshot_repo(hf_api, repo_factory, tmp_path):
+    repo_id = repo_factory("snapshot-download-batch2")
+    upload_dir = tmp_path / "upload"
+    write_tree(
+        upload_dir,
+        {
+            "config.json": '{"model_type": "gpt2", "batch": 2}',
+            "vocab.json": '{"a": 1, "b": 2}',
+            "data/train.csv": "col1,col2\n1,2\n",
+        },
+    )
+    hf_api.upload_folder(
+        folder_path=upload_dir,
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Upload snapshot fixture",
+    )
+    return repo_id
+
+
+
+def test_snapshot_download_local_files_only_reuses_existing_local_dir(
+    hf_api, hf_session, repo_factory, tmp_path
+):
+    repo_id = _create_snapshot_repo(hf_api, repo_factory, tmp_path)
+    cache_dir = tmp_path / "cache"
+    local_dir = tmp_path / "local-snapshot"
+
+    snapshot_path = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+            local_dir=local_dir,
+        )
+    )
+    local_only_path = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+            local_dir=local_dir,
+            local_files_only=True,
+        )
+    )
+
+    assert snapshot_path == local_dir
+    assert local_only_path == local_dir
+    assert (local_only_path / "config.json").read_text(encoding="utf-8") == '{"model_type": "gpt2", "batch": 2}'
+    assert (local_only_path / "data" / "train.csv").read_text(encoding="utf-8") == "col1,col2\n1,2\n"
+
+
+
+def test_snapshot_download_local_files_only_missing_cache_raises(hf_session, repo_factory, tmp_path):
+    repo_id = repo_factory("snapshot-local-only-miss")
+
+    with pytest.raises(LocalEntryNotFoundError):
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache",
+            local_files_only=True,
+        )
+
+
+
+def test_snapshot_download_refreshes_existing_local_dir_after_new_commit(
+    hf_api, hf_session, repo_factory, tmp_path
+):
+    repo_id = _create_snapshot_repo(hf_api, repo_factory, tmp_path)
+    cache_dir = tmp_path / "cache"
+    local_dir = tmp_path / "local-snapshot"
+
+    snapshot_download(
+        repo_id=repo_id,
+        repo_type="model",
+        endpoint=hf_session["endpoint"],
+        token=hf_session["token"],
+        cache_dir=cache_dir,
+        local_dir=local_dir,
+    )
+
+    hf_api.upload_file(
+        path_or_fileobj=b'{"model_type": "gpt2", "batch": 2, "version": 2}',
+        path_in_repo="config.json",
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Update config.json",
+    )
+    hf_api.upload_file(
+        path_or_fileobj=b"new content\n",
+        path_in_repo="notes/new.txt",
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Add notes/new.txt",
+    )
+
+    refreshed_path = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+            local_dir=local_dir,
+        )
+    )
+
+    assert refreshed_path == local_dir
+    assert (refreshed_path / "config.json").read_text(encoding="utf-8") == '{"model_type": "gpt2", "batch": 2, "version": 2}'
+    assert (refreshed_path / "notes" / "new.txt").read_text(encoding="utf-8") == "new content\n"


### PR DESCRIPTION
## Summary
- start batch 2 of the `huggingface_hub` compatibility rollout for deeper download and cache semantics
- keep the scope limited to `hf_hub_download` and `snapshot_download` current-head cache and `local_dir` behaviors
- update the roadmap/checklist in the same PR as the executable work

## Test plan
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_file_download_batch2.py -q`
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_snapshot_download_batch2.py -q`
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub -q`
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run tests/integration/test_downloads.py`
- [ ] `cargo test --workspace`

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)