### PR TITLE
test(hf-hub): batch-3 private repo and auth correctness

### DIFF
--- a/crates/hub-api/src/auth.rs
+++ b/crates/hub-api/src/auth.rs
@@ -2,8 +2,9 @@ use argon2::{
     password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
 };
+use axum::http::HeaderMap;
 use common::AppError;
-use db_layer::PgPool;
+use db_layer::{queries::repositories::RepoRow, PgPool};
 use rand::Rng;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -64,10 +65,44 @@ pub async fn resolve_bearer_token(pool: &PgPool, token: &str) -> Result<Uuid, Ap
 }
 
 /// Extract and resolve Bearer token from request headers.
-pub fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<&str> {
-    let value = headers
-        .get(axum::http::header::AUTHORIZATION)?
-        .to_str()
-        .ok()?;
+pub fn extract_bearer(headers: &HeaderMap) -> Option<&str> {
+    let value = headers.get(axum::http::header::AUTHORIZATION)?.to_str().ok()?;
     value.strip_prefix("Bearer ")
+}
+
+pub async fn resolve_optional_bearer_token(
+    pool: &PgPool,
+    headers: &HeaderMap,
+) -> Result<Option<Uuid>, AppError> {
+    match extract_bearer(headers) {
+        Some(token) => resolve_bearer_token(pool, token).await.map(Some),
+        None => Ok(None),
+    }
+}
+
+pub fn ensure_repo_read_access(
+    repo: &RepoRow,
+    full_name: &str,
+    requester_id: Option<Uuid>,
+) -> Result<(), AppError> {
+    if !repo.private || requester_id == Some(repo.owner_id) {
+        return Ok(());
+    }
+
+    if requester_id.is_some() {
+        return Err(AppError::Forbidden(format!(
+            "access to repo '{}' is forbidden",
+            full_name
+        )));
+    }
+
+    Err(AppError::NotFound(format!("repo '{}' not found", full_name)))
+}
+
+pub fn ensure_repo_write_access(repo: &RepoRow, requester_id: Uuid) -> Result<(), AppError> {
+    if repo.owner_id == requester_id {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden("not the repo owner".into()))
+    }
 }

--- a/crates/hub-api/src/auth.rs
+++ b/crates/hub-api/src/auth.rs
@@ -66,7 +66,10 @@ pub async fn resolve_bearer_token(pool: &PgPool, token: &str) -> Result<Uuid, Ap
 
 /// Extract and resolve Bearer token from request headers.
 pub fn extract_bearer(headers: &HeaderMap) -> Option<&str> {
-    let value = headers.get(axum::http::header::AUTHORIZATION)?.to_str().ok()?;
+    let value = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
     value.strip_prefix("Bearer ")
 }
 
@@ -96,7 +99,10 @@ pub fn ensure_repo_read_access(
         )));
     }
 
-    Err(AppError::NotFound(format!("repo '{}' not found", full_name)))
+    Err(AppError::NotFound(format!(
+        "repo '{}' not found",
+        full_name
+    )))
 }
 
 pub fn ensure_repo_write_access(repo: &RepoRow, requester_id: Uuid) -> Result<(), AppError> {

--- a/crates/hub-api/src/routes/files.rs
+++ b/crates/hub-api/src/routes/files.rs
@@ -14,6 +14,7 @@ use sha2::Digest;
 /// GET /api/{type}s/:owner/:repo/tree/:revision[/*path]
 pub async fn tree_list(
     State(state): State<HubState>,
+    headers: HeaderMap,
     Path(params): Path<Vec<(String, String)>>,
 ) -> Result<Json<Vec<TreeEntry>>, AppError> {
     let params: std::collections::HashMap<_, _> = params.into_iter().collect();
@@ -30,6 +31,8 @@ pub async fn tree_list(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
+    let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
+    auth::ensure_repo_read_access(&repo_row, &full_name, requester_id)?;
 
     let files = db_layer::queries::repo_files::list_files(
         &state.pool,
@@ -142,10 +145,30 @@ pub struct PreuploadFileResponse {
 }
 
 pub async fn preupload(
-    State(_state): State<HubState>,
-    Path(_params): Path<Vec<(String, String)>>,
+    State(state): State<HubState>,
+    headers: HeaderMap,
+    Path(params): Path<Vec<(String, String)>>,
     Json(req): Json<PreuploadRequest>,
 ) -> Result<Json<PreuploadResponse>, AppError> {
+    let token = auth::extract_bearer(&headers)
+        .ok_or_else(|| AppError::Unauthorized("missing bearer token".into()))?;
+    let user_id = auth::resolve_bearer_token(&state.pool, token).await?;
+
+    let params: std::collections::HashMap<_, _> = params.into_iter().collect();
+    let owner = params
+        .get("owner")
+        .ok_or_else(|| AppError::BadRequest("missing owner".into()))?;
+    let repo = params
+        .get("repo")
+        .ok_or_else(|| AppError::BadRequest("missing repo".into()))?;
+    let full_name = format!("{}/{}", owner, repo);
+
+    let repo_row = db_layer::queries::repositories::find_repo_by_full_name(&state.pool, &full_name)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
+    auth::ensure_repo_write_access(&repo_row, user_id)?;
+
     let files: Vec<PreuploadFileResponse> = req
         .files
         .iter()
@@ -191,6 +214,7 @@ pub async fn commit(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
+    auth::ensure_repo_write_access(&repo_row, user_id)?;
 
     // Parse NDJSON body
     let body_str = String::from_utf8(body.to_vec())
@@ -349,6 +373,7 @@ pub struct CommitResponse {
 pub async fn resolve_file(
     State(state): State<HubState>,
     method: Method,
+    headers: HeaderMap,
     Path(params): Path<Vec<(String, String)>>,
 ) -> Result<Response, AppError> {
     let params: std::collections::HashMap<_, _> = params.into_iter().collect();
@@ -367,6 +392,8 @@ pub async fn resolve_file(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
+    let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
+    auth::ensure_repo_read_access(&repo_row, &full_name, requester_id)?;
 
     let file = db_layer::queries::repo_files::find_file(&state.pool, repo_row.id, path)
         .await

--- a/crates/hub-api/src/routes/repos.rs
+++ b/crates/hub-api/src/routes/repos.rs
@@ -177,9 +177,7 @@ pub async fn update_repo_settings(
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::NotFound(format!("repo {} not found", full_name)))?;
 
-    if repo_row.owner_id != user_id {
-        return Err(AppError::Forbidden("not the repo owner".into()));
-    }
+    auth::ensure_repo_write_access(&repo_row, user_id)?;
 
     // Ideally we would update the visibility in the database here, but the queries module
     // might not have `update_repo_visibility` yet. For now, we will return success to make the client happy.
@@ -191,6 +189,7 @@ pub async fn update_repo_settings(
 
 pub async fn repo_info(
     State(state): State<HubState>,
+    headers: HeaderMap,
     Path((owner, repo)): Path<(String, String)>,
 ) -> Result<Json<RepoInfoResponse>, AppError> {
     let full_name = format!("{}/{}", owner, repo);
@@ -198,6 +197,8 @@ pub async fn repo_info(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
+    let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
+    auth::ensure_repo_read_access(&repo_row, &full_name, requester_id)?;
 
     let files = db_layer::queries::repo_files::list_files(&state.pool, repo_row.id, None)
         .await
@@ -228,6 +229,7 @@ pub async fn repo_info(
 
 pub async fn repo_info_revision(
     State(state): State<HubState>,
+    headers: HeaderMap,
     Path((owner, repo, _revision)): Path<(String, String, String)>,
 ) -> Result<Json<RepoInfoResponse>, AppError> {
     // For now, ignore revision and return the latest head info
@@ -236,6 +238,8 @@ pub async fn repo_info_revision(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
+    let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
+    auth::ensure_repo_read_access(&repo_row, &full_name, requester_id)?;
 
     let files = db_layer::queries::repo_files::list_files(&state.pool, repo_row.id, None)
         .await
@@ -266,13 +270,16 @@ pub async fn repo_info_revision(
 
 pub async fn list_models(
     State(state): State<HubState>,
+    headers: HeaderMap,
 ) -> Result<Json<Vec<RepoInfoResponse>>, AppError> {
+    let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
     let repos = db_layer::queries::repositories::list_repos_by_type(&state.pool, "model")
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
     let responses = repos
         .into_iter()
+        .filter(|repo| !repo.private || requester_id == Some(repo.owner_id))
         .map(|repo| repo_to_response(&repo, vec![], &state.config.hub_base_url))
         .collect();
 
@@ -281,13 +288,16 @@ pub async fn list_models(
 
 pub async fn list_datasets(
     State(state): State<HubState>,
+    headers: HeaderMap,
 ) -> Result<Json<Vec<RepoInfoResponse>>, AppError> {
+    let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
     let repos = db_layer::queries::repositories::list_repos_by_type(&state.pool, "dataset")
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
     let responses = repos
         .into_iter()
+        .filter(|repo| !repo.private || requester_id == Some(repo.owner_id))
         .map(|repo| repo_to_response(&repo, vec![], &state.config.hub_base_url))
         .collect();
 
@@ -328,9 +338,7 @@ pub async fn delete_repo(
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
 
-    if repo.owner_id != user_id {
-        return Err(AppError::Forbidden("not the repo owner".into()));
-    }
+    auth::ensure_repo_write_access(&repo, user_id)?;
 
     db_layer::queries::repositories::delete_repo(&state.pool, repo.id)
         .await

--- a/docs/hf_hub_testing_roadmap.md
+++ b/docs/hf_hub_testing_roadmap.md
@@ -26,7 +26,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 | --- | --- | --- | --- | --- | --- |
 | Batch 1 | done | Core `HfApi` CRUD, basic `hf_hub_download`, metadata/cache basics, and core `snapshot_download` flows with pattern filters. | `tests/test_hf_api.py`, `tests/test_file_download.py`, `tests/test_snapshot_download.py` | [#17](https://github.com/Atena-IT/xet-backend/issues/17) | [#23](https://github.com/Atena-IT/xet-backend/pull/23) |
 | Batch 2 | done | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | [#24](https://github.com/Atena-IT/xet-backend/issues/24) | [#25](https://github.com/Atena-IT/xet-backend/pull/25) |
-| Batch 3 | in_progress | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | [#26](https://github.com/Atena-IT/xet-backend/issues/26) | TBD |
+| Batch 3 | in_progress | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | [#26](https://github.com/Atena-IT/xet-backend/issues/26) | [#27](https://github.com/Atena-IT/xet-backend/pull/27) |
 | Batch 4 | planned | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | TBD | TBD |
 | Batch 5 | planned | Branch, tag, and PR-oriented Hub workflows, only if still desired after batch 4. | `tests/test_hf_api.py`, `tests/test_cli_discussions.py` | TBD | TBD |
 | Batch 6 | planned | LFS/Xet-heavy and filesystem-heavy compatibility where it directly exercises supported server behavior. | `tests/test_hf_file_system.py`, `tests/test_xet_upload.py`, `tests/test_xet_download.py`, `tests/test_repocard.py` | TBD | TBD |
@@ -89,6 +89,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 
 **Status:** `in_progress`
 - Issue: [#26](https://github.com/Atena-IT/xet-backend/issues/26)
+- PR: [#27](https://github.com/Atena-IT/xet-backend/pull/27)
 
 **Target**
 - enforce private/public behavior consistently

--- a/docs/hf_hub_testing_roadmap.md
+++ b/docs/hf_hub_testing_roadmap.md
@@ -25,8 +25,8 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 | Batch | Status | Scope summary | Upstream modules | Issue | PR |
 | --- | --- | --- | --- | --- | --- |
 | Batch 1 | done | Core `HfApi` CRUD, basic `hf_hub_download`, metadata/cache basics, and core `snapshot_download` flows with pattern filters. | `tests/test_hf_api.py`, `tests/test_file_download.py`, `tests/test_snapshot_download.py` | [#17](https://github.com/Atena-IT/xet-backend/issues/17) | [#23](https://github.com/Atena-IT/xet-backend/pull/23) |
-| Batch 2 | in_progress | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | [#24](https://github.com/Atena-IT/xet-backend/issues/24) | [#25](https://github.com/Atena-IT/xet-backend/pull/25) |
-| Batch 3 | planned | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | TBD | TBD |
+| Batch 2 | done | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | [#24](https://github.com/Atena-IT/xet-backend/issues/24) | [#25](https://github.com/Atena-IT/xet-backend/pull/25) |
+| Batch 3 | in_progress | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | [#26](https://github.com/Atena-IT/xet-backend/issues/26) | TBD |
 | Batch 4 | planned | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | TBD | TBD |
 | Batch 5 | planned | Branch, tag, and PR-oriented Hub workflows, only if still desired after batch 4. | `tests/test_hf_api.py`, `tests/test_cli_discussions.py` | TBD | TBD |
 | Batch 6 | planned | LFS/Xet-heavy and filesystem-heavy compatibility where it directly exercises supported server behavior. | `tests/test_hf_file_system.py`, `tests/test_xet_upload.py`, `tests/test_xet_download.py`, `tests/test_repocard.py` | TBD | TBD |
@@ -62,7 +62,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 
 ### Batch 2 — deeper download and cache semantics
 
-**Status:** `in_progress`
+**Status:** `done`
 - Issue: [#24](https://github.com/Atena-IT/xet-backend/issues/24)
 - PR: [#25](https://github.com/Atena-IT/xet-backend/pull/25)
 
@@ -87,7 +87,8 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 
 ### Batch 3 — private repo and auth correctness
 
-**Status:** `planned`
+**Status:** `in_progress`
+- Issue: [#26](https://github.com/Atena-IT/xet-backend/issues/26)
 
 **Target**
 - enforce private/public behavior consistently

--- a/resources/hf_hub_compat/checklist.json
+++ b/resources/hf_hub_compat/checklist.json
@@ -127,7 +127,10 @@
         "number": 26,
         "url": "https://github.com/Atena-IT/xet-backend/issues/26"
       },
-      "pr": null,
+      "pr": {
+        "number": 27,
+        "url": "https://github.com/Atena-IT/xet-backend/pull/27"
+      },
       "depends_on": ["batch2"],
       "exit_criteria": [
         "Targeted auth and visibility tests pass locally",

--- a/resources/hf_hub_compat/checklist.json
+++ b/resources/hf_hub_compat/checklist.json
@@ -7,7 +7,7 @@
   },
   "strategy": {
     "tracking_model": "single_active_batch",
-    "current_pointer": "batch2",
+    "current_pointer": "batch3",
     "status_values": ["done", "in_progress", "planned", "blocked", "out_of_scope"]
   },
   "non_goals": [
@@ -64,7 +64,7 @@
     {
       "id": "batch2",
       "title": "Deeper download and cache semantics",
-      "status": "in_progress",
+      "status": "done",
       "scope": [
         "More hf_hub_download semantics beyond batch-1 happy paths",
         "More snapshot_download semantics beyond batch-1 happy paths",
@@ -104,7 +104,7 @@
     {
       "id": "batch3",
       "title": "Private repo and auth correctness",
-      "status": "planned",
+      "status": "in_progress",
       "scope": [
         "Private/public enforcement",
         "Token and no-token behavior",
@@ -123,7 +123,10 @@
         "crates/hub-api/src/routes/files.rs",
         "auth-adjacent route/query files"
       ],
-      "issue": null,
+      "issue": {
+        "number": 26,
+        "url": "https://github.com/Atena-IT/xet-backend/issues/26"
+      },
       "pr": null,
       "depends_on": ["batch2"],
       "exit_criteria": [

--- a/tests/integration/hf_hub/conftest.py
+++ b/tests/integration/hf_hub/conftest.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 os.environ.setdefault("HF_HUB_DISABLE_SYMLINKS_WARNING", "1")
 
@@ -48,12 +49,25 @@ def hf_api(hf_session: dict[str, str]) -> HfApi:
 
 
 @pytest.fixture
+def second_user(hf_endpoint: str) -> dict[str, str]:
+    username = os.environ.get("HF_TEST_SECOND_USERNAME") or f"pytest-hf-hub-alt-{uuid.uuid4().hex[:8]}"
+    password = os.environ.get("HF_TEST_SECOND_PASSWORD", DEFAULT_PASSWORD)
+    token = register_or_login(hf_endpoint, username, password)
+    return {
+        "endpoint": hf_endpoint,
+        "username": username,
+        "password": password,
+        "token": token,
+    }
+
+
+@pytest.fixture
 def repo_factory(hf_api: HfApi, hf_session: dict[str, str]):
     created_repos: list[tuple[str, str]] = []
 
-    def create_repo(prefix: str, repo_type: str = "model") -> str:
+    def create_repo(prefix: str, repo_type: str = "model", private: bool = False) -> str:
         repo_id = make_repo_id(hf_session["username"], prefix)
-        hf_api.create_repo(repo_id=repo_id, repo_type=repo_type)
+        hf_api.create_repo(repo_id=repo_id, repo_type=repo_type, private=private)
         created_repos.append((repo_id, repo_type))
         return repo_id
 

--- a/tests/integration/hf_hub/test_auth_batch3.py
+++ b/tests/integration/hf_hub/test_auth_batch3.py
@@ -1,0 +1,43 @@
+import pytest
+import requests
+from huggingface_hub import HfApi
+from huggingface_hub.errors import HfHubHTTPError
+
+
+def test_whoami_token_false_raises_value_error(hf_session):
+    api = HfApi(endpoint=hf_session["endpoint"], token=hf_session["token"])
+
+    with pytest.raises(ValueError, match="token=False"):
+        api.whoami(token=False)
+
+
+def test_whoami_without_or_with_invalid_token_returns_401(hf_session):
+    endpoint = hf_session["endpoint"]
+
+    no_token_response = requests.get(f"{endpoint}/api/whoami-v2", timeout=10)
+    invalid_token_response = requests.get(
+        f"{endpoint}/api/whoami-v2",
+        headers={"Authorization": "Bearer ox_invalid"},
+        timeout=10,
+    )
+
+    assert no_token_response.status_code == 401
+    assert no_token_response.headers["X-Error-Message"] == "missing bearer token"
+    assert invalid_token_response.status_code == 401
+    assert invalid_token_response.headers["X-Error-Message"] == "invalid token"
+
+
+def test_private_repo_non_owner_upload_file_is_forbidden(hf_api, hf_session, second_user, repo_factory):
+    repo_id = repo_factory("auth-private-upload", private=True)
+    other_api = HfApi(endpoint=hf_session["endpoint"], token=second_user["token"])
+
+    with pytest.raises(HfHubHTTPError, match="403"):
+        other_api.upload_file(
+            path_or_fileobj=b"blocked",
+            path_in_repo="blocked.txt",
+            repo_id=repo_id,
+            repo_type="model",
+            commit_message="Blocked upload",
+        )
+
+    assert not hf_api.file_exists(repo_id, "blocked.txt")

--- a/tests/integration/hf_hub/test_repo_visibility_batch3.py
+++ b/tests/integration/hf_hub/test_repo_visibility_batch3.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+
+import pytest
+import requests
+from huggingface_hub import HfApi, hf_hub_download
+from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError
+
+
+
+def _create_private_repo(hf_api, repo_factory):
+    repo_id = repo_factory("repo-visibility-private", private=True)
+    content = b'{"private": true, "batch": 3}'
+    hf_api.upload_file(
+        path_or_fileobj=content,
+        path_in_repo="config.json",
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Upload private config",
+    )
+    return repo_id, content
+
+
+
+def _repo_info_url(endpoint: str, repo_id: str) -> str:
+    return f"{endpoint}/api/models/{repo_id}"
+
+
+
+def _resolve_url(endpoint: str, repo_id: str) -> str:
+    return f"{endpoint}/{repo_id}/resolve/main/config.json"
+
+
+
+def _auth_headers(token: str | None) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+
+def test_private_repo_owner_can_read_metadata_and_file(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, expected_content = _create_private_repo(hf_api, repo_factory)
+
+    info = hf_api.model_info(repo_id)
+    downloaded_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache",
+        )
+    )
+
+    assert info.private is True
+    assert downloaded_path.read_bytes() == expected_content
+
+
+
+def test_private_repo_anonymous_looks_missing_to_client_and_http(hf_api, hf_session, repo_factory):
+    repo_id, _ = _create_private_repo(hf_api, repo_factory)
+    api = HfApi(endpoint=hf_session["endpoint"], token=hf_session["token"])
+
+    assert not api.repo_exists(repo_id, token=False)
+    assert not api.file_exists(repo_id, "config.json", token=False)
+    with pytest.raises(RepositoryNotFoundError):
+        api.model_info(repo_id, token=False)
+
+    repo_response = requests.get(_repo_info_url(hf_session["endpoint"], repo_id), timeout=10)
+    file_response = requests.head(_resolve_url(hf_session["endpoint"], repo_id), timeout=10)
+
+    assert repo_response.status_code == 404
+    assert file_response.status_code == 404
+
+
+
+def test_private_repo_invalid_token_is_unauthorized(hf_api, hf_session, repo_factory):
+    repo_id, _ = _create_private_repo(hf_api, repo_factory)
+    headers = _auth_headers("ox_invalid")
+
+    repo_response = requests.get(
+        _repo_info_url(hf_session["endpoint"], repo_id),
+        headers=headers,
+        timeout=10,
+    )
+    file_response = requests.head(
+        _resolve_url(hf_session["endpoint"], repo_id),
+        headers=headers,
+        timeout=10,
+    )
+
+    assert repo_response.status_code == 401
+    assert repo_response.headers["X-Error-Message"] == "invalid token"
+    assert file_response.status_code == 401
+    assert file_response.headers["X-Error-Message"] == "invalid token"
+
+
+
+def test_private_repo_non_owner_gets_forbidden(hf_api, hf_session, second_user, repo_factory):
+    repo_id, _ = _create_private_repo(hf_api, repo_factory)
+    other_api = HfApi(endpoint=hf_session["endpoint"], token=second_user["token"])
+    headers = _auth_headers(second_user["token"])
+
+    with pytest.raises(HfHubHTTPError, match="403"):
+        other_api.model_info(repo_id)
+    with pytest.raises(HfHubHTTPError, match="403"):
+        other_api.file_exists(repo_id, "config.json")
+
+    repo_response = requests.get(
+        _repo_info_url(hf_session["endpoint"], repo_id),
+        headers=headers,
+        timeout=10,
+    )
+    file_response = requests.head(
+        _resolve_url(hf_session["endpoint"], repo_id),
+        headers=headers,
+        timeout=10,
+    )
+
+    assert repo_response.status_code == 403
+    assert file_response.status_code == 403
+
+
+
+def test_private_repo_cached_download_can_be_reused_without_token(
+    hf_api, hf_session, repo_factory, tmp_path
+):
+    repo_id, expected_content = _create_private_repo(hf_api, repo_factory)
+    cache_dir = tmp_path / "cache"
+
+    cached_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=cache_dir,
+        )
+    )
+    local_only_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            endpoint=hf_session["endpoint"],
+            token=False,
+            cache_dir=cache_dir,
+            local_files_only=True,
+        )
+    )
+
+    assert cached_path == local_only_path
+    assert local_only_path.read_bytes() == expected_content


### PR DESCRIPTION
## Summary
- start batch 3 of the `huggingface_hub` compatibility rollout for private repo visibility and auth correctness
- keep the scope limited to protected repo metadata, protected file reads, `token=False` behavior, and one narrow non-owner mutation boundary
- update the roadmap/checklist in the same PR as the executable work

## Test plan
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_auth_batch3.py -q`
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_repo_visibility_batch3.py -q`
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub -q`
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run tests/integration/test_downloads.py`

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)