### PR TITLE
test(hf-hub): batch-4 revision and history semantics

### DIFF
--- a/crates/hub-api/src/auth.rs
+++ b/crates/hub-api/src/auth.rs
@@ -112,3 +112,17 @@ pub fn ensure_repo_write_access(repo: &RepoRow, requester_id: Uuid) -> Result<()
         Err(AppError::Forbidden("not the repo owner".into()))
     }
 }
+
+pub fn ensure_supported_repo_revision(
+    repo: &RepoRow,
+    revision: &str,
+) -> Result<(), AppError> {
+    if revision == "main" || repo.head_sha.as_deref() == Some(revision) {
+        Ok(())
+    } else {
+        Err(AppError::NotFound(format!(
+            "revision '{}' not found",
+            revision
+        )))
+    }
+}

--- a/crates/hub-api/src/auth.rs
+++ b/crates/hub-api/src/auth.rs
@@ -113,10 +113,7 @@ pub fn ensure_repo_write_access(repo: &RepoRow, requester_id: Uuid) -> Result<()
     }
 }
 
-pub fn ensure_supported_repo_revision(
-    repo: &RepoRow,
-    revision: &str,
-) -> Result<(), AppError> {
+pub fn ensure_supported_repo_revision(repo: &RepoRow, revision: &str) -> Result<(), AppError> {
     if revision == "main" || repo.head_sha.as_deref() == Some(revision) {
         Ok(())
     } else {

--- a/crates/hub-api/src/routes/files.rs
+++ b/crates/hub-api/src/routes/files.rs
@@ -24,6 +24,9 @@ pub async fn tree_list(
     let repo = params
         .get("repo")
         .ok_or_else(|| AppError::BadRequest("missing repo".into()))?;
+    let revision = params
+        .get("revision")
+        .ok_or_else(|| AppError::BadRequest("missing revision".into()))?;
     let path = params.get("path");
 
     let full_name = format!("{}/{}", owner, repo);
@@ -33,6 +36,7 @@ pub async fn tree_list(
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
     let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
     auth::ensure_repo_read_access(&repo_row, &full_name, requester_id)?;
+    auth::ensure_supported_repo_revision(&repo_row, revision)?;
 
     let files = db_layer::queries::repo_files::list_files(
         &state.pool,
@@ -383,6 +387,9 @@ pub async fn resolve_file(
     let repo = params
         .get("repo")
         .ok_or_else(|| AppError::BadRequest("missing repo".into()))?;
+    let revision = params
+        .get("revision")
+        .ok_or_else(|| AppError::BadRequest("missing revision".into()))?;
     let path = params
         .get("path")
         .ok_or_else(|| AppError::BadRequest("missing path".into()))?;
@@ -394,6 +401,7 @@ pub async fn resolve_file(
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
     let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
     auth::ensure_repo_read_access(&repo_row, &full_name, requester_id)?;
+    auth::ensure_supported_repo_revision(&repo_row, revision)?;
 
     let file = db_layer::queries::repo_files::find_file(&state.pool, repo_row.id, path)
         .await

--- a/crates/hub-api/src/routes/repos.rs
+++ b/crates/hub-api/src/routes/repos.rs
@@ -230,9 +230,8 @@ pub async fn repo_info(
 pub async fn repo_info_revision(
     State(state): State<HubState>,
     headers: HeaderMap,
-    Path((owner, repo, _revision)): Path<(String, String, String)>,
+    Path((owner, repo, revision)): Path<(String, String, String)>,
 ) -> Result<Json<RepoInfoResponse>, AppError> {
-    // For now, ignore revision and return the latest head info
     let full_name = format!("{}/{}", owner, repo);
     let repo_row = db_layer::queries::repositories::find_repo_by_full_name(&state.pool, &full_name)
         .await
@@ -240,6 +239,7 @@ pub async fn repo_info_revision(
         .ok_or_else(|| AppError::NotFound(format!("repo '{}' not found", full_name)))?;
     let requester_id = auth::resolve_optional_bearer_token(&state.pool, &headers).await?;
     auth::ensure_repo_read_access(&repo_row, &full_name, requester_id)?;
+    auth::ensure_supported_repo_revision(&repo_row, &revision)?;
 
     let files = db_layer::queries::repo_files::list_files(&state.pool, repo_row.id, None)
         .await

--- a/docs/hf_hub_testing_roadmap.md
+++ b/docs/hf_hub_testing_roadmap.md
@@ -27,7 +27,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 | Batch 1 | done | Core `HfApi` CRUD, basic `hf_hub_download`, metadata/cache basics, and core `snapshot_download` flows with pattern filters. | `tests/test_hf_api.py`, `tests/test_file_download.py`, `tests/test_snapshot_download.py` | [#17](https://github.com/Atena-IT/xet-backend/issues/17) | [#23](https://github.com/Atena-IT/xet-backend/pull/23) |
 | Batch 2 | done | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | [#24](https://github.com/Atena-IT/xet-backend/issues/24) | [#25](https://github.com/Atena-IT/xet-backend/pull/25) |
 | Batch 3 | done | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | [#26](https://github.com/Atena-IT/xet-backend/issues/26) | [#27](https://github.com/Atena-IT/xet-backend/pull/27) |
-| Batch 4 | in_progress | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | [#28](https://github.com/Atena-IT/xet-backend/issues/28) | TBD |
+| Batch 4 | in_progress | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | [#28](https://github.com/Atena-IT/xet-backend/issues/28) | [#29](https://github.com/Atena-IT/xet-backend/pull/29) |
 | Batch 5 | planned | Branch, tag, and PR-oriented Hub workflows, only if still desired after batch 4. | `tests/test_hf_api.py`, `tests/test_cli_discussions.py` | TBD | TBD |
 | Batch 6 | planned | LFS/Xet-heavy and filesystem-heavy compatibility where it directly exercises supported server behavior. | `tests/test_hf_file_system.py`, `tests/test_xet_upload.py`, `tests/test_xet_download.py`, `tests/test_repocard.py` | TBD | TBD |
 
@@ -114,6 +114,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 
 **Status:** `in_progress`
 - Issue: [#28](https://github.com/Atena-IT/xet-backend/issues/28)
+- PR: [#29](https://github.com/Atena-IT/xet-backend/pull/29)
 
 **Target**
 - verify commit SHA and revision correctness beyond always returning latest head

--- a/docs/hf_hub_testing_roadmap.md
+++ b/docs/hf_hub_testing_roadmap.md
@@ -26,8 +26,8 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 | --- | --- | --- | --- | --- | --- |
 | Batch 1 | done | Core `HfApi` CRUD, basic `hf_hub_download`, metadata/cache basics, and core `snapshot_download` flows with pattern filters. | `tests/test_hf_api.py`, `tests/test_file_download.py`, `tests/test_snapshot_download.py` | [#17](https://github.com/Atena-IT/xet-backend/issues/17) | [#23](https://github.com/Atena-IT/xet-backend/pull/23) |
 | Batch 2 | done | Deeper download and cache semantics for `hf_hub_download` and `snapshot_download`, including cache reuse and local-dir/cache edge cases that fit the current architecture. | `tests/test_file_download.py`, `tests/test_snapshot_download.py`, `tests/test_cache_layout.py`, `tests/test_utils_cache.py` | [#24](https://github.com/Atena-IT/xet-backend/issues/24) | [#25](https://github.com/Atena-IT/xet-backend/pull/25) |
-| Batch 3 | in_progress | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | [#26](https://github.com/Atena-IT/xet-backend/issues/26) | [#27](https://github.com/Atena-IT/xet-backend/pull/27) |
-| Batch 4 | planned | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | TBD | TBD |
+| Batch 3 | done | Private repo enforcement, token/no-token behavior, and correct 401/403/404 semantics for protected resources. | `tests/test_hf_api.py`, `tests/test_file_download.py` | [#26](https://github.com/Atena-IT/xet-backend/issues/26) | [#27](https://github.com/Atena-IT/xet-backend/pull/27) |
+| Batch 4 | in_progress | Revision and history semantics, including commit SHA handling and non-HEAD lookup behavior. | `tests/test_hf_api.py`, `tests/test_snapshot_download.py` | [#28](https://github.com/Atena-IT/xet-backend/issues/28) | TBD |
 | Batch 5 | planned | Branch, tag, and PR-oriented Hub workflows, only if still desired after batch 4. | `tests/test_hf_api.py`, `tests/test_cli_discussions.py` | TBD | TBD |
 | Batch 6 | planned | LFS/Xet-heavy and filesystem-heavy compatibility where it directly exercises supported server behavior. | `tests/test_hf_file_system.py`, `tests/test_xet_upload.py`, `tests/test_xet_download.py`, `tests/test_repocard.py` | TBD | TBD |
 
@@ -87,7 +87,7 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 
 ### Batch 3 — private repo and auth correctness
 
-**Status:** `in_progress`
+**Status:** `done`
 - Issue: [#26](https://github.com/Atena-IT/xet-backend/issues/26)
 - PR: [#27](https://github.com/Atena-IT/xet-backend/pull/27)
 
@@ -112,11 +112,13 @@ It distills the raw upstream test analysis from [issue #11](https://github.com/A
 
 ### Batch 4 — revision and history semantics
 
-**Status:** `planned`
+**Status:** `in_progress`
+- Issue: [#28](https://github.com/Atena-IT/xet-backend/issues/28)
 
 **Target**
 - verify commit SHA and revision correctness beyond always returning latest head
-- add lookup/listing semantics that matter for practical download and metadata workflows
+- accept `main` and the current head commit SHA as valid read revisions in the current storage model
+- reject missing revisions instead of silently serving the latest head
 
 **Likely local files**
 - `tests/integration/hf_hub/test_revisions_batch4.py`

--- a/resources/hf_hub_compat/checklist.json
+++ b/resources/hf_hub_compat/checklist.json
@@ -163,7 +163,10 @@
         "number": 28,
         "url": "https://github.com/Atena-IT/xet-backend/issues/28"
       },
-      "pr": null,
+      "pr": {
+        "number": 29,
+        "url": "https://github.com/Atena-IT/xet-backend/pull/29"
+      },
       "depends_on": ["batch3"],
       "exit_criteria": [
         "Targeted revision tests pass locally",

--- a/resources/hf_hub_compat/checklist.json
+++ b/resources/hf_hub_compat/checklist.json
@@ -7,7 +7,7 @@
   },
   "strategy": {
     "tracking_model": "single_active_batch",
-    "current_pointer": "batch3",
+    "current_pointer": "batch4",
     "status_values": ["done", "in_progress", "planned", "blocked", "out_of_scope"]
   },
   "non_goals": [
@@ -104,7 +104,7 @@
     {
       "id": "batch3",
       "title": "Private repo and auth correctness",
-      "status": "in_progress",
+      "status": "done",
       "scope": [
         "Private/public enforcement",
         "Token and no-token behavior",
@@ -142,10 +142,11 @@
     {
       "id": "batch4",
       "title": "Revision and history semantics",
-      "status": "planned",
+      "status": "in_progress",
       "scope": [
         "Commit SHA and revision correctness",
-        "Listing and lookup semantics beyond always returning latest head"
+        "Accept main and current head SHA as valid read revisions",
+        "Reject missing revisions instead of silently serving latest head"
       ],
       "upstream_modules": [
         "tests/test_hf_api.py",
@@ -158,7 +159,10 @@
         "crates/hub-api/src/routes/repos.rs",
         "commit and file lookup paths involved in revision resolution"
       ],
-      "issue": null,
+      "issue": {
+        "number": 28,
+        "url": "https://github.com/Atena-IT/xet-backend/issues/28"
+      },
       "pr": null,
       "depends_on": ["batch3"],
       "exit_criteria": [

--- a/tests/integration/hf_hub/test_revisions_batch4.py
+++ b/tests/integration/hf_hub/test_revisions_batch4.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pytest
+from huggingface_hub import hf_hub_download, snapshot_download
+from huggingface_hub.errors import RevisionNotFoundError
+
+
+
+def _create_revision_repo(hf_api, repo_factory, tmp_path):
+    repo_id = repo_factory("revisions")
+    upload_dir = tmp_path / "upload"
+    upload_dir.mkdir()
+    (upload_dir / "config.json").write_text('{"revision": 1}', encoding="utf-8")
+    (upload_dir / "nested.txt").write_text("nested", encoding="utf-8")
+    hf_api.upload_folder(
+        folder_path=upload_dir,
+        repo_id=repo_id,
+        repo_type="model",
+        commit_message="Upload revision fixture",
+    )
+    head_sha = hf_api.model_info(repo_id).sha
+    return repo_id, head_sha
+
+
+
+def test_revision_exists_for_main_and_current_head_sha(hf_api, repo_factory, tmp_path):
+    repo_id, head_sha = _create_revision_repo(hf_api, repo_factory, tmp_path)
+
+    assert hf_api.revision_exists(repo_id, "main")
+    assert hf_api.revision_exists(repo_id, head_sha)
+
+
+
+def test_revision_exists_false_for_missing_revision(hf_api, repo_factory, tmp_path):
+    repo_id, _ = _create_revision_repo(hf_api, repo_factory, tmp_path)
+
+    assert not hf_api.revision_exists(repo_id, "does-not-exist")
+
+
+
+def test_model_info_and_download_accept_current_head_sha(hf_api, hf_session, repo_factory, tmp_path):
+    repo_id, head_sha = _create_revision_repo(hf_api, repo_factory, tmp_path)
+
+    info = hf_api.model_info(repo_id, revision=head_sha)
+    downloaded_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            revision=head_sha,
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache-download",
+        )
+    )
+    snapshot_path = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            revision=head_sha,
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache-snapshot",
+        )
+    )
+
+    assert info.sha == head_sha
+    assert downloaded_path.read_text(encoding="utf-8") == '{"revision": 1}'
+    assert (snapshot_path / "config.json").read_text(encoding="utf-8") == '{"revision": 1}'
+    assert (snapshot_path / "nested.txt").read_text(encoding="utf-8") == "nested"
+
+
+
+def test_model_info_download_and_snapshot_reject_missing_revision(
+    hf_api, hf_session, repo_factory, tmp_path
+):
+    repo_id, _ = _create_revision_repo(hf_api, repo_factory, tmp_path)
+
+    with pytest.raises(RevisionNotFoundError):
+        hf_api.model_info(repo_id, revision="does-not-exist")
+
+    with pytest.raises(RevisionNotFoundError):
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            repo_type="model",
+            revision="does-not-exist",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache-missing-download",
+        )
+
+    with pytest.raises(RevisionNotFoundError):
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="model",
+            revision="does-not-exist",
+            endpoint=hf_session["endpoint"],
+            token=hf_session["token"],
+            cache_dir=tmp_path / "cache-missing-snapshot",
+        )


### PR DESCRIPTION
## Summary
- start batch 4 of the `huggingface_hub` compatibility rollout for revision-aware metadata and download behavior
- keep the scope limited to `main`, current head commit SHA, and correct missing-revision failures in the existing storage model
- update the roadmap/checklist in the same PR as the executable work

## Test plan
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub/test_revisions_batch4.py -q`
- [ ] `HF_ENDPOINT=http://localhost:8080 uv run --with pytest --with huggingface_hub --with requests pytest tests/integration/hf_hub -q`
- [ ] `cargo test --workspace`

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)